### PR TITLE
fix: add ImageKit domain to next config image remotePatterns

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,7 +10,12 @@ const nextConfig: NextConfig = {
           {
             protocol: "https",
             hostname: "m.media-amazon.com",
-          }
+          },
+          {
+            protocol: "https",
+            hostname: "ik.imagekit.io",
+            port: "",
+          },
         ]
     }
 };


### PR DESCRIPTION
# Add ImageKit Domain Configuration

## Changes
- Add ImageKit domain (ik.imagekit.io) to Next.js image configuration

## Why
- Required for Next.js Image component to properly render images uploaded through ImageKit
- Fixes image loading issues for student card previews
- Prevents build-time errors for external image domains

## Technical Details
- Updated next.config.ts to include ik.imagekit.io in remotePatterns
- Added with HTTPS protocol requirement
- No port specification needed for standard HTTPS

## Related
- Depends on PR #7 (Student Card Upload Integration)