### PR TITLE
feat: integrate upstash redis rate limiting

### DIFF
--- a/app/too-fast/page.tsx
+++ b/app/too-fast/page.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+const Page = () => {
+  return (
+    <main className='root-container flex min-h-screen items-center justify-center'>
+        <h1 className="font-bebas-neue text-5xl font-bold text-light-100">
+            Too many requests from your IP address. Please try again later.
+        </h1>
+        <p className='mt-3 max-w-xl text-center text-light-400'>
+            If you think this is an error, please contact us at giftgabanakgosi@gmail.com
+        </p>
+    </main>
+  )
+}
+
+export default Page

--- a/database/redis.ts
+++ b/database/redis.ts
@@ -1,0 +1,10 @@
+import config from "@/lib/config";
+import { Redis } from "@upstash/redis";
+
+
+const redis = new Redis({
+    url: config.env.upstash.redisUrl,
+    token: config.env.upstash.redisToken,
+})
+
+export default redis;

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -7,6 +7,10 @@ const config = {
             urlEndpoint: process.env.NEXT_PUBLIC_IMAGEKIT_URL_ENDPOINT!,
         },
         databaseUrl: process.env.DATABASE_URL!,
+        upstash:{
+            redisUrl: process.env.UPSTASH_REDIS_URL!,
+            redisToken: process.env.UPSTASH_REDIS_TOKEN!
+        }
     }
 }
 

--- a/lib/ratelimit.ts
+++ b/lib/ratelimit.ts
@@ -1,0 +1,12 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import redis from "@/database/redis";
+
+
+const ratelimit = new Ratelimit({
+  redis,
+  limiter: Ratelimit.fixedWindow(5, "1m"),
+  analytics: true,
+  prefix: "@upstash/ratelimit",
+});
+
+export default ratelimit;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@radix-ui/react-slot": "^1.1.1",
         "@radix-ui/react-toast": "^1.2.4",
         "@types/bcrypt": "^5.0.2",
+        "@upstash/ratelimit": "^2.0.5",
+        "@upstash/redis": "^1.34.3",
         "aws-sdk": "^2.1692.0",
         "bcrypt": "^5.1.1",
         "bcryptjs": "^2.4.3",
@@ -2454,6 +2456,39 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.5.tgz",
+      "integrity": "sha512-1FRv0cs3ZlBjCNOCpCmKYmt9BYGIJf0J0R3pucOPE88R21rL7jNjXG+I+rN/BVOvYJhI9niRAS/JaSNjiSICxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.34.3",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.34.3.tgz",
+      "integrity": "sha512-VT25TyODGy/8ljl7GADnJoMmtmJ1F8d84UXfGonRRF8fWYJz7+2J6GzW+a6ETGtk4OyuRTt7FRSvFG5GvrfSdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0"
+      }
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -3321,6 +3356,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-toast": "^1.2.4",
     "@types/bcrypt": "^5.0.2",
+    "@upstash/ratelimit": "^2.0.5",
+    "@upstash/redis": "^1.34.3",
     "aws-sdk": "^2.1692.0",
     "bcrypt": "^5.1.1",
     "bcryptjs": "^2.4.3",


### PR DESCRIPTION
# Redis Rate Limiting Integration

## Changes
- Integrated Upstash Redis for rate limiting functionality
- Added rate limiting configuration (5 requests per minute)
- Created error redirect page for rate-limited requests
- Set up Redis configuration and environment variables

## New Dependencies
- @upstash/ratelimit@2.0.5
- @upstash/redis@1.34.3

## Implementation Details
- Added Redis configuration in database folder
- Created rate limiting utility in lib/ratelimit.ts
- Implemented rate limiting checks in auth endpoints
- Added too-fast error page for graceful handling of rate-limited requests

## Required Environment Variables
```env
UPSTASH_REDIS_URL=
UPSTASH_REDIS_TOKEN=